### PR TITLE
Improve assertions

### DIFF
--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -52,25 +52,25 @@ class ConverterTest extends TestCase
     {
         $priceEuro = $this->converter->from(new Price(500, 'USD'))->convertToBase();
 
-        $this->assertEquals('EUR', $priceEuro->currency());
+        $this->assertSame('EUR', $priceEuro->currency());
 
-        $this->assertEquals(1000, $priceEuro->amount());
+        $this->assertSame(1000.0, $priceEuro->amount());
 
         $price = $this->converter->from(new Price(500, 'GBP'))->convertToBase();
 
-        $this->assertEquals(250, $price->amount());
+        $this->assertSame(250.0, $price->amount());
 
         $this->converter = new Converter(new Currency('FCU', 10, 2), $this->repository);
 
         $priceBase = $this->converter->from(new Price(500, 'USD'))->convertToBase();
 
-        $this->assertEquals('FCU', $priceBase->currency());
+        $this->assertSame('FCU', $priceBase->currency());
 
-        $this->assertEquals(10000, $priceBase->amount());
+        $this->assertSame(10000.0, $priceBase->amount());
 
         $price = $this->converter->from(new Price(500, 'GBP'))->convertToBase();
 
-        $this->assertEquals(2500, $price->amount());
+        $this->assertSame(2500.0, $price->amount());
     }
 
     /** @test */
@@ -80,19 +80,19 @@ class ConverterTest extends TestCase
 
         $this->assertNotEquals(500, $price->amount());
 
-        $this->assertEquals('GBP', $price->currency());
+        $this->assertSame('GBP', $price->currency());
 
         $price = $this->converter->from(new Price(500, 'USD'))->to('USD')->convert();
 
-        $this->assertEquals(500, $price->amount());
+        $this->assertSame(500.0, $price->amount());
 
-        $this->assertEquals('USD', $price->currency());
+        $this->assertSame('USD', $price->currency());
 
         $price = $this->converter->from(new Price(500, 'USD'))->to('EUR')->convert();
 
-        $this->assertEquals(1000, $price->amount());
+        $this->assertSame(1000.0, $price->amount());
 
-        $this->assertEquals('EUR', $price->currency());
+        $this->assertSame('EUR', $price->currency());
     }
 
     /** @test */
@@ -110,11 +110,11 @@ class ConverterTest extends TestCase
 
         $currency = new Currency('FCU', 2, 0);
 
-        $this->assertEquals(4, $this->converter->convertAmount($currency));
+        $this->assertSame(4.0, $this->converter->convertAmount($currency));
 
         $this->converter->from(new Price(4, 'USD'))->to('EUR');
 
-        $this->assertEquals(2, $this->converter->convertAmount($currency));
+        $this->assertSame(2.0, $this->converter->convertAmount($currency));
     }
 
     /** @test */
@@ -124,16 +124,16 @@ class ConverterTest extends TestCase
 
         $currency = new Currency('FCU', 2.655, 2);
 
-        $this->assertEquals(5.31, $this->converter->convertAmount($currency));
+        $this->assertSame(5.31, $this->converter->convertAmount($currency));
 
         $this->converter->from(new Price(4, 'USD'))->to('EUR');
 
-        $this->assertEquals(1.51, $this->converter->convertAmount($currency));
+        $this->assertSame(1.51, $this->converter->convertAmount($currency));
 
         $currency = new Currency('FCU', 2.655, 0);
 
         $this->converter->from(new Price(4, 'USD'));
 
-        $this->assertEquals(2, $this->converter->convertAmount($currency));
+        $this->assertSame(2.0, $this->converter->convertAmount($currency));
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assertion equals checking strict.